### PR TITLE
destroy method

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -974,6 +974,15 @@
 					}
 				)
 			}
+			
+			function destroy(){
+				if(isScrollableH) horizontalBar.remove();
+				if(isScrollableV) verticalBar.remove();
+
+				pane.children().unwrap().unwrap();
+				elem.removeClass("jspScrollable").removeAttr("style").removeAttr("tabindex").removeData("jsp");
+				elem.unbind('.jsp');
+			}
 
 			// Public API
 			$.extend(
@@ -1103,6 +1112,11 @@
 					hijackInternalLinks: function()
 					{
 						hijackInternalLinks();
+					},
+					// It simple distroy a the jscrollpane for that element.
+					destroy: function()
+					{
+							destroy();
 					}
 				}
 			);


### PR DESCRIPTION
Hi, 
I made a very simple destroy method to be able to remove the jScrollPane from a element.
For me is working great, maybe I miss some things, but I think is a good first aproach

The method is in the public API so you need to call it like this.

element.data("jsp").destroy();

thanks the this great plugin
