### PR TITLE
Hash in URL Breaks jScrollPane with JQuery 1.4.4

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -926,7 +926,7 @@
 						return;
 					}
 
-					if (e.length && pane.find(e)) {
+					if (e.length && pane.find(location.hash)) {
 						// nasty workaround but it appears to take a little while before the hash has done its thing
 						// to the rendered page so we just wait until the container's scrollTop has been messed up.
 						if (container.scrollTop() == 0) {


### PR DESCRIPTION
With the new version of jQuery (1.4.4) the hash functionality in jScrollPane is causing javascript errors. Specifically, the observeHash() method is causing an error when it calls into pane.find().

I've checked in a fix on our branch, if you want to pull it in.
