### PR TITLE
When maintaining scroll position, stay sticky to the bottom or right

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -126,8 +126,8 @@
 				} else {
 					elem.css('width', '');
 
-					maintainAtBottom = isCloseToBottom();
-					maintainAtRight = isCloseToRight();
+					maintainAtBottom = settings.maintainBottom && isCloseToBottom();
+					maintainAtRight  = settings.maintainRight  && isCloseToRight();
 
 					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem.outerHeight() != paneHeight;
 
@@ -1348,6 +1348,8 @@
 	$.fn.jScrollPane.defaults = {
 		showArrows					: false,
 		maintainPosition			: true,
+		maintainBottom				: false,
+		maintainRight				: false,
 		clickOnTrack				: true,
 		autoReinitialise			: false,
 		autoReinitialiseDelay		: 500,


### PR DESCRIPTION
This patch changes the behaviour if `maintainPosition` is on, and the user is scrolled all the way (or very almost all the way) to the bottom or right, and the content is updated to add more content to the bottom or right.

Previously, jScrollPane maintained the absolute number of pixels scrolled downwards or rightwards. I think it's nicer to users if instead, it maintains the fact that it is scrolled all the way down to the bottom/right, and stays "sticky" to the bottom.

For example, the logs on Chrome's developer console do this. It's awesome, because you can follow the logs (just scroll all the way down to the bottom, and it will stay at the bottom even when new log messages are added), but you can also scroll up (without it jumping down whenever a new log message appears).
