### PR TITLE
jQuery call chaining is broken if no elements are selected

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -1338,8 +1338,7 @@
 			settings[this] = settings[this] || settings.speed;
 		});
 
-		var ret;
-		this.each(
+		return this.each(
 			function()
 			{
 				var elem = $(this), jspApi = elem.data('jsp');
@@ -1349,10 +1348,8 @@
 					jspApi = new JScrollPane(elem, settings);
 					elem.data('jsp', jspApi);
 				}
-				ret = ret ? ret.add(elem) : elem;
 			}
 		);
-		return ret;
 	};
 
 	$.fn.jScrollPane.defaults = {


### PR DESCRIPTION
`jQuery('#this-selector-does-not-exist').jScrollPane()` currently returns `undefined`, which means it cannot safely be chained with other jQuery method calls. It should stick to the jQuery plugin convention of returning `this`, irrespective of whether it matches any elements.
