### PR TITLE
Added setting to run a full initialise()

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -143,10 +143,13 @@
 					}
 
 					// If nothing changed since last check...
-					if (!hasContainingSpaceChanged && previousContentWidth == contentWidth && pane.outerHeight() == contentHeight) {
-						elem.width(paneWidth);
-						return;
+					if(!settings.fullReinitialise) {
+						if (!hasContainingSpaceChanged && previousContentWidth == contentWidth && pane.outerHeight() == contentHeight) {
+							elem.width(paneWidth);
+							return;
+						}
 					}
+					
 					previousContentWidth = contentWidth;
 					
 					pane.css('width', '');
@@ -1384,7 +1387,8 @@
 		keyboardSpeed				: 0,
 		initialDelay                : 300,        // Delay before starting repeating
 		speed						: 30,		// Default speed when others falsey
-		scrollPagePercent			: .8		// Percent of visible area scrolled when pageUp/Down or track area pressed
+		scrollPagePercent			: .8,		// Percent of visible area scrolled when pageUp/Down or track area pressed
+		fullReinitialise			: false
 	};
 
 })(jQuery,this);


### PR DESCRIPTION
Hi,

This pull request is relating to my post in the jScrollPane google group:  http://groups.google.com/group/jscrollpane/browse_thread/thread/e946e1e70c3f92f0

I added a 'settings' field to do a full initialise which skips the return statement in Initialise() if the system finds that the window dimensions have not changed.  

The issue this solved was that if a scroll pane started with many elements which required scrolling was updated by ajax to a list of only 1 or 2 elements which did not require scrolling, the scroll bar would not be updated.  It would keep the same scroll track of the first list.   In another scenario, if a 2nd list was updated (ajax) with 0 elements the scroll bar would be removed.  But if the list is updated again with many elements the scroll bar would not reappear.  I traced this to the if statement on line 146 which prevents the initialise() function from completing if certain conditions are met.

Thank you!
James
