### PR TITLE
Scroll Wheel Fix

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -867,7 +867,10 @@
 					mwEvent,
 					function (event, delta, deltaX, deltaY) {
 						var dX = horizontalDragPosition, dY = verticalDragPosition;
-						jsp.scrollBy(deltaX * settings.mouseWheelSpeed, -deltaY * settings.mouseWheelSpeed, false);
+						// This prevents the scroll from going horizontal when one is only scrolling vertical and vice versa.
+                                                if(deltaY != 0) { jsp.scrollByY(-deltaY * settings.mouseWheelSpeed); }
+                                                if(deltaX != 0) { jsp.scrollByX(deltaX * settings.mouseWheelSpeed); }
+
 						// return true if there was no movement so rest of screen can scroll
 						return dX == horizontalDragPosition && dY == verticalDragPosition;
 					}


### PR DESCRIPTION
Prevents the scroll from going horizontal when one is only scrolling vertical and vice versa. This has to be done because the scroll by functions are written so that they scroll at least one pixel.
