### PR TITLE
Fixes potential issues with inline scripts

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -81,7 +81,7 @@
 			{
 
 				var /*firstChild, lastChild, */isMaintainingPositon, lastContentX, lastContentY,
-						hasContainingSpaceChanged, originalScrollTop, originalScrollLeft,
+						hasContainingSpaceChanged, originalScrollTop, originalScrollLeft, elemChildren,
 						maintainAtBottom = false, maintainAtRight = false;
 
 				settings = s;
@@ -103,13 +103,15 @@
 
 					elem.width(paneWidth);
 					
-					pane = $('<div class="jspPane" />').css('padding', originalPadding).append(elem.children());
+					elemChildren = elem.children().remove();
+					pane = $('<div class="jspPane" />').css('padding', originalPadding);
 					container = $('<div class="jspContainer" />')
 						.css({
 							'width': paneWidth + 'px',
 							'height': paneHeight + 'px'
 						}
 					).append(pane).appendTo(elem);
+					pane.append(elemChildren);
 
 					/*
 					// Move any margins from the first and last children up to the container so they can still
@@ -1387,4 +1389,3 @@
 	};
 
 })(jQuery,this);
-


### PR DESCRIPTION
This change reorders the dom manipulation slightly.

Element children will not be added back to the scroll pane until after the scroll pane has been added to the dom tree first.
