### PR TITLE
scrollToElement fails when element has position of 0

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -822,7 +822,7 @@
 				} else if (eleTop + eleHeight > maxVisibleEleTop) { // element is below viewport
 					destY = eleTop - paneHeight + eleHeight + settings.verticalGutter;
 				}
-				if (destY) {
+				if (typeof destY !== 'undefined') {
 					scrollToY(destY, animate);
 				}
 				
@@ -833,7 +833,7 @@
 	            } else if (eleLeft + eleWidth > maxVisibleEleLeft) { // element is to the right viewport
 	                destX = eleLeft - paneWidth + eleWidth + settings.horizontalGutter;
 	            }
-	            if (destX) {
+	            if (typeof destX !== 'undefined') {
 	                scrollToX(destX, animate);
 	            }
 


### PR DESCRIPTION
Found an issue where if you are trying to use scrollToElement with an element that is positioned at either top 0 or left 0, jscrollpane fails to scroll to that element.

Checking if a variable is undefined using a regular
'if(variable)'
is generally unsafe, especially when you're dealing with coordinates.
Since you potentially run into the issue of
variable = 0
if(variable)
