### PR TITLE
Reinitialize timer is not removed when scrollpane is destroyed

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -1138,6 +1138,11 @@
 				elem.replaceWith(originalElement.append(pane.children()));
 				originalElement.scrollTop(currentY);
 				originalElement.scrollLeft(currentX);
+
+				// clear reinitialize timer if active
+				if (reinitialiseInterval) {
+					clearInterval(reinitialiseInterval);
+				}
 			}
 
 			// Public API


### PR DESCRIPTION
I am adding a small patch to make sure the setInterval timer is cleared when the scrollpane is destroyed.
