### PR TITLE
Improved handling of #-hash links

### DIFF
--- a/anchors.html
+++ b/anchors.html
@@ -70,9 +70,7 @@
 				<strong>Note</strong> that the link hijacking functionality is off by default (as it has a small
 				performance overhead so if you don't need it you might as well not have it). To enable it pass
 				<strong><a href="settings.html#hijackInternalLinks">hijackInternalLinks</a>: true</strong> in with
-				your settings (as I do on this page). If you have changed the content of your page and want to re-apply
-				the link hijacking then you can call the <a href="api.html#hijackInternalLinks">hijackInternalLinks</a>
-				method on the jScrollPane API.
+				your settings (as I do on this page). Internally only one live event is bound to the document body.
 			</p>
 			<div class="scroll-pane">
 				<p id="para1">


### PR DESCRIPTION
Currently there is an option to bind a click-handler to all links on a page starting with a hash-sign:
hijackInternalLinks

It allows the user to click on anchors which link to elements contained within a jsp-container.

There were several bugs and oddities with this feature:
1. The performance wasn't too good. It binds a click handler to each anchor on the page. After changing the page content (using ajax), you had to call jsp.reinitialise() to update possible new links.
2. If the user navigated to a url containing a hash, the page jumped to the element and the scrollbar disappeared. (I mean, when the user opened a tab like http://jscrollpane.kelvinluck.com/anchors.html#para4)
3. Only the element ids were searched. Anchors in the form of  &lt;a name="test"> &lt;/a> were not supported.
4. When using a  &lt;base href="..."> element in the head of the document or when prepending the hash with the current url, the link was not hijacked. Only links, were the attribute started with # were hijacked.
When the user was on page http://example.com/index.html and clicked a link  &lt;a href="index.html#test"> the click was handled by the browser instead of by jsp.

This Pull request fixes these bugs:
1. I use .delegate() on the body to bind only one event.
I don't know which jQuery versions should be supported by jsp. delegate requires jQuery >= 1.4.3. We could also use .on() to bind the event, but this would require jQuery >= 1.7
1. The location.hash was escaped and then given to $(hash). The # got replaced by %23. So the dom-query looked like $('%23test') for a hash of #test. No element was ever found and jsp didn't handle the hash. This is fixed by using hash.substr(1) to strip the leading #
2. I also search for anchors with a name of the hash: $('a[name="' + hash + '"]');
3. I check if the href of the link (without the #-part) is the same as the location.href

Currently you have to explicitly enable the hijack functionality. I would recommend to enable it by default or remove the option completly. With only one live-event bound, there is no (or only a negligible) performance overhead.
