### PR TITLE
Only scroll element into view, if it is not visible

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -1094,7 +1094,11 @@
 
 					if (container[0].scrollIntoView) {
 						// also scroll to the top of the container (if it is not visible)
-						container[0].scrollIntoView();
+						var scrollTop = $(window).scrollTop();
+						var elementTop = element.offset().top;
+						if (elementTop < scrollTop || elementTop > scrollTop + $(window).height()) {
+							container[0].scrollIntoView();
+						}
 					}
 
 					// jsp handled this event, prevent the browser default (scrolling :P)


### PR DESCRIPTION
In response to [the comment on my previous pull request](https://github.com/rvock/jScrollPane/commit/c9e70e8929cacf232f16814d0ed136bfbbd76ae3#commitcomment-1198171) I've fixed the code to scroll the browser window only, if the jsp-container is not in the view area.

I thaught, that scrollIntoView() would handle this automatically...
