### PR TITLE
fix both inline script call

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -1389,6 +1389,7 @@
 				if (jspApi) {
 					jspApi.reinitialise(settings);
 				} else {
+					$("script",elem).remove();
 					jspApi = new JScrollPane(elem, settings);
 					elem.data('jsp', jspApi);
 				}


### PR DESCRIPTION
if their is inline script in scrolable element, it will be called 2 times (on load and on jScrollPane call)
