### PR TITLE
Sizzle in current jQuery 1.7.2 throws a Syntax error without the quotes

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -1389,7 +1389,7 @@
 				if (jspApi) {
 					jspApi.reinitialise(settings);
 				} else {
-					$("script",elem).filter('[type=text/javascript],not([type])').remove();
+					$("script",elem).filter('[type="text/javascript"],not([type])').remove();
 					jspApi = new JScrollPane(elem, settings);
 					elem.data('jsp', jspApi);
 				}


### PR DESCRIPTION
I know jScrollPane isn't officially supported on jQuery 1.7.2 but it seems to work fine with the quotes for my app so it would be great if you can merge this.
