### PR TITLE
Options to place scrollbar outside the container

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -61,7 +61,7 @@
 		// JScrollPane "class" - public methods are available through $('selector').data('jsp')
 		function JScrollPane(elem, s)
 		{
-			var settings, jsp = this, pane, paneWidth, paneHeight, container, contentWidth, contentHeight,
+			var settings, jsp = this, pane, paneWidth, paneHeight, container, scrollContainer, contentWidth, contentHeight,
 				percentInViewH, percentInViewV, isScrollableV, isScrollableH, verticalDrag, dragMaxY,
 				verticalDragPosition, horizontalDrag, dragMaxX, horizontalDragPosition,
 				verticalBar, verticalTrack, scrollbarWidth, verticalTrackHeight, verticalDragHeight, arrowUp, arrowDown,
@@ -112,6 +112,9 @@
 						}
 					).append(pane).appendTo(elem);
 
+                                        
+                                        scrollContainer = settings.isHorizontalScrollOutside ? elem : container;
+                                        
 					/*
 					// Move any margins from the first and last children up to the container so they can still
 					// collapse with neighbouring elements as they would before jScrollPane 
@@ -153,7 +156,7 @@
 					pane.css('width', '');
 					elem.width(paneWidth);
 
-					container.find('>.jspVerticalBar,>.jspHorizontalBar').remove().end();
+					scrollContainer.find('>.jspVerticalBar,>.jspHorizontalBar').remove().end();
 				}
 
 				pane.css('overflow', 'auto');
@@ -279,7 +282,7 @@
                     }
 
                     verticalTrackHeight = paneHeight;
-                    elem.find('>.jspVerticalBar>.jspCap:visible,>.jspVerticalBar>.jspArrow').each(
+                    scrollContainer.find('>.jspVerticalBar>.jspCap:visible,>.jspVerticalBar>.jspArrow').each(
                         function()
                         {
                             verticalTrackHeight -= $(this).outerHeight();
@@ -342,12 +345,7 @@
 
 			function initialiseHorizontalScroll()
 			{
-                           var scrollContainer = container;
-                           
-                            if(settings.isHorizontalScrollOutside) {
-                                scrollContainer = elem;
-                            }
-                            
+
 				if (isScrollableH) {
 					scrollContainer.append(
 						$('<div class="jspHorizontalBar" />').append(
@@ -417,7 +415,7 @@
 
 			function sizeHorizontalScrollbar()
 			{
-				container.find('>.jspHorizontalBar>.jspCap:visible,>.jspHorizontalBar>.jspArrow').each(
+				scrollContainer.find('>.jspHorizontalBar>.jspCap:visible,>.jspHorizontalBar>.jspArrow').each(
 					function()
 					{
 						horizontalTrackWidth -= $(this).outerWidth();
@@ -1409,8 +1407,8 @@
 	};
 
 	$.fn.jScrollPane.defaults = {
-		isHorizontalScrollOutside		: false,
-		isVerticalScrollOutside                 : false,
+		isHorizontalScrollOutside		: true,
+		isVerticalScrollOutside                 : true,
                 
 		showArrows				: false,
 		maintainPosition			: true,

--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -236,84 +236,90 @@
 				elem.trigger('jsp-initialised', [isScrollableH || isScrollableV]);
 			}
 
-			function initialiseVerticalScroll()
-			{
-				if (isScrollableV) {
+            function initialiseVerticalScroll()
+            {     
+                if (isScrollableV) {
+                    
+                    var scrollContainer = container;
+                           
+                    if(settings.isVerticalScrollOutside) {
+                        scrollContainer = elem;
+                    }
 
-					container.append(
-						$('<div class="jspVerticalBar" />').append(
-							$('<div class="jspCap jspCapTop" />'),
-							$('<div class="jspTrack" />').append(
-								$('<div class="jspDrag" />').append(
-									$('<div class="jspDragTop" />'),
-									$('<div class="jspDragBottom" />')
-								)
-							),
-							$('<div class="jspCap jspCapBottom" />')
-						)
-					);
+                    scrollContainer.append(
+                        $('<div class="jspVerticalBar" />').append(
+                            $('<div class="jspCap jspCapTop" />'),
+                            $('<div class="jspTrack" />').append(
+                                $('<div class="jspDrag" />').append(
+                                    $('<div class="jspDragTop" />'),
+                                    $('<div class="jspDragBottom" />')
+                                    )
+                                ),
+                            $('<div class="jspCap jspCapBottom" />')
+                            )
+                        );
 
-					verticalBar = container.find('>.jspVerticalBar');
-					verticalTrack = verticalBar.find('>.jspTrack');
-					verticalDrag = verticalTrack.find('>.jspDrag');
+                    verticalBar = scrollContainer.find('>.jspVerticalBar');
+                    verticalTrack = verticalBar.find('>.jspTrack');
+                    verticalDrag = verticalTrack.find('>.jspDrag');
 
-					if (settings.showArrows) {
-						arrowUp = $('<a class="jspArrow jspArrowUp" />').bind(
-							'mousedown.jsp', getArrowScroll(0, -1)
-						).bind('click.jsp', nil);
-						arrowDown = $('<a class="jspArrow jspArrowDown" />').bind(
-							'mousedown.jsp', getArrowScroll(0, 1)
-						).bind('click.jsp', nil);
-						if (settings.arrowScrollOnHover) {
-							arrowUp.bind('mouseover.jsp', getArrowScroll(0, -1, arrowUp));
-							arrowDown.bind('mouseover.jsp', getArrowScroll(0, 1, arrowDown));
-						}
+                    if (settings.showArrows) {
+                        arrowUp = $('<a class="jspArrow jspArrowUp" />').bind(
+                            'mousedown.jsp', getArrowScroll(0, -1)
+                            ).bind('click.jsp', nil);
+                        arrowDown = $('<a class="jspArrow jspArrowDown" />').bind(
+                            'mousedown.jsp', getArrowScroll(0, 1)
+                            ).bind('click.jsp', nil);
+                        if (settings.arrowScrollOnHover) {
+                            arrowUp.bind('mouseover.jsp', getArrowScroll(0, -1, arrowUp));
+                            arrowDown.bind('mouseover.jsp', getArrowScroll(0, 1, arrowDown));
+                        }
 
-						appendArrows(verticalTrack, settings.verticalArrowPositions, arrowUp, arrowDown);
-					}
+                        appendArrows(verticalTrack, settings.verticalArrowPositions, arrowUp, arrowDown);
+                    }
 
-					verticalTrackHeight = paneHeight;
-					container.find('>.jspVerticalBar>.jspCap:visible,>.jspVerticalBar>.jspArrow').each(
-						function()
-						{
-							verticalTrackHeight -= $(this).outerHeight();
-						}
-					);
+                    verticalTrackHeight = paneHeight;
+                    elem.find('>.jspVerticalBar>.jspCap:visible,>.jspVerticalBar>.jspArrow').each(
+                        function()
+                        {
+                            verticalTrackHeight -= $(this).outerHeight();
+                        }
+                        );
 
 
-					verticalDrag.hover(
-						function()
-						{
-							verticalDrag.addClass('jspHover');
-						},
-						function()
-						{
-							verticalDrag.removeClass('jspHover');
-						}
-					).bind(
-						'mousedown.jsp',
-						function(e)
-						{
-							// Stop IE from allowing text selection
-							$('html').bind('dragstart.jsp selectstart.jsp', nil);
+                    verticalDrag.hover(
+                        function()
+                        {
+                            verticalDrag.addClass('jspHover');
+                        },
+                        function()
+                        {
+                            verticalDrag.removeClass('jspHover');
+                        }
+                        ).bind(
+                        'mousedown.jsp',
+                        function(e)
+                        {
+                            // Stop IE from allowing text selection
+                            $('html').bind('dragstart.jsp selectstart.jsp', nil);
 
-							verticalDrag.addClass('jspActive');
+                            verticalDrag.addClass('jspActive');
 
-							var startY = e.pageY - verticalDrag.position().top;
+                            var startY = e.pageY - verticalDrag.position().top;
 
-							$('html').bind(
-								'mousemove.jsp',
-								function(e)
-								{
-									positionDragY(e.pageY - startY, false);
-								}
-							).bind('mouseup.jsp mouseleave.jsp', cancelDrag);
-							return false;
-						}
-					);
-					sizeVerticalScrollbar();
-				}
-			}
+                            $('html').bind(
+                                'mousemove.jsp',
+                                function(e)
+                                {
+                                    positionDragY(e.pageY - startY, false);
+                                }
+                                ).bind('mouseup.jsp mouseleave.jsp', cancelDrag);
+                            return false;
+                        }
+                        );
+                    sizeVerticalScrollbar();
+                }
+            }
 
 			function sizeVerticalScrollbar()
 			{
@@ -336,9 +342,14 @@
 
 			function initialiseHorizontalScroll()
 			{
+                           var scrollContainer = container;
+                           
+                            if(settings.isHorizontalScrollOutside) {
+                                scrollContainer = elem;
+                            }
+                            
 				if (isScrollableH) {
-
-					container.append(
+					scrollContainer.append(
 						$('<div class="jspHorizontalBar" />').append(
 							$('<div class="jspCap jspCapLeft" />'),
 							$('<div class="jspTrack" />').append(
@@ -351,7 +362,7 @@
 						)
 					);
 
-					horizontalBar = container.find('>.jspHorizontalBar');
+					horizontalBar = scrollContainer.find('>.jspHorizontalBar');
 					horizontalTrack = horizontalBar.find('>.jspTrack');
 					horizontalDrag = horizontalTrack.find('>.jspDrag');
 
@@ -1398,7 +1409,10 @@
 	};
 
 	$.fn.jScrollPane.defaults = {
-		showArrows					: false,
+		isHorizontalScrollOutside		: false,
+		isVerticalScrollOutside                 : false,
+                
+		showArrows				: false,
 		maintainPosition			: true,
 		stickToBottom				: false,
 		stickToRight				: false,


### PR DESCRIPTION
Sometimes we need to place scrollbar outside the container. 
Actually you can do it without changing markup, only with css, but in some case (e.g. border-radius applied to scrollPane) it's imposible.

This fix adds two options into plugin, and provide you to extract scroll from container in markup, and place in root element.
