### PR TITLE
Displaying outline for .jspScrollable container in some browsers

### DIFF
--- a/style/jquery.jscrollpane.css
+++ b/style/jquery.jscrollpane.css
@@ -5,6 +5,11 @@
  * may not operate correctly without them.
  */
 
+.jspScrollable
+{
+  outline: 0;
+}
+
 .jspContainer
 {
 	overflow: hidden;


### PR DESCRIPTION
In webkit, firefox and IE displayed outline when clicking on container edge with `jspScrollable` class.
