### PR TITLE
Fixing issue 220

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -829,9 +829,9 @@
 				viewportTop = contentPositionY();
 				maxVisibleEleTop = viewportTop + paneHeight;
 				if (eleTop < viewportTop || stickToTop) { // element is above viewport
-					destY = eleTop - settings.verticalGutter;
+					destY = eleTop - settings.horizontalGutter;
 				} else if (eleTop + eleHeight > maxVisibleEleTop) { // element is below viewport
-					destY = eleTop - paneHeight + eleHeight + settings.verticalGutter;
+					destY = eleTop - paneHeight + eleHeight + settings.horizontalGutter;
 				}
 				if (!isNaN(destY)) {
 					scrollToY(destY, animate);


### PR DESCRIPTION
https://github.com/vitch/jScrollPane/issues/220

When calculating whether the element is above/below viewport
settings.verticalGutter is used instead of settings.horizontalGutter.
The same problem is with with calculating whether the element is to the
left/right viewport.

So when I set { verticalGutter: 10 } and use scrollToElement function
the pane is scrolled 10px beneath needed though verticalGutter should
not effect it at all
