### PR TITLE
Working correctly with box-sizing 'border-box' keeping the original padd...

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -78,17 +78,13 @@
 				originalElement = elem.clone(false, false).empty(),
 				mwEvent = $.fn.mwheelIntent ? 'mwheelIntent.jsp' : 'mousewheel.jsp';
 
-			if (elem.css('box-sizing') === 'border-box') {
-				originalPadding = 0;
-				originalPaddingTotalWidth = 0;
-			} else {
-				originalPadding = elem.css('paddingTop') + ' ' +
-									elem.css('paddingRight') + ' ' +
-									elem.css('paddingBottom') + ' ' +
-									elem.css('paddingLeft');	
-				originalPaddingTotalWidth = (parseInt(elem.css('paddingLeft'), 10) || 0) +
-											(parseInt(elem.css('paddingRight'), 10) || 0);
-			}
+			originalBoxSizing = elem.css('box-sizing');
+			originalPadding = elem.css('paddingTop') + ' ' +
+								elem.css('paddingRight') + ' ' +
+								elem.css('paddingBottom') + ' ' +
+								elem.css('paddingLeft');
+			originalPaddingTotalWidth = originalBoxSizing === 'border-box' ? 0 : (parseInt(elem.css('paddingLeft'), 10) || 0) +
+										(parseInt(elem.css('paddingRight'), 10) || 0);
 
 			function initialise(s)
 			{
@@ -115,8 +111,8 @@
 					paneHeight = elem.innerHeight();
 
 					elem.width(paneWidth);
-					
-					pane = $('<div class="jspPane" />').css('padding', originalPadding).append(elem.children());
+
+					pane = $('<div class="jspPane" />').css({'padding': originalPadding, 'box-sizing' : originalBoxSizing}).append(elem.children());
 					container = $('<div class="jspContainer" />')
 						.css({
 							'width': paneWidth + 'px',
@@ -335,7 +331,7 @@
 				scrollbarWidth = settings.verticalGutter + verticalTrack.outerWidth();
 
 				// Make the pane thinner to allow for the vertical scrollbar
-				pane.width(paneWidth - scrollbarWidth - originalPaddingTotalWidth);
+				pane.css('width', paneWidth - scrollbarWidth - originalPaddingTotalWidth);
 
 				// Add margin to the left of the pane if scrollbars are on that side (to position
 				// the scrollbar on the left or right set it's left or right property in CSS)
@@ -453,7 +449,7 @@
 				}
 				// reflow content
 				if (isScrollableH) {
-					pane.width((container.outerWidth() - originalPaddingTotalWidth) + 'px');
+					pane.css('width', (container.outerWidth() - originalPaddingTotalWidth) + 'px');
 				}
 				contentHeight = pane.outerHeight();
 				percentInViewV = contentHeight / paneHeight;


### PR DESCRIPTION
The way 'box-sizing : border-box' was handled, the original horizontal padding missing inside the pane.

To keep the original padding, the pane is also given the original box-sizing. 
The originalPaddingTotalWidth, which is used for measurements calculations, is set to 0, as it it already accounted for in the paneWidth value.
