### PR TITLE
Fix left positioning when jScrollPane is positioned left of content

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -202,8 +202,9 @@
 				if (!(isScrollableH || isScrollableV)) {
 					elem.removeClass('jspScrollable');
 					pane.css({
-            top: 0,
-            left: 0,
+					        top: 0,
+					        left: 0,
+					        'margin-left': 0,
 						width: container.width() - originalPaddingTotalWidth
 					});
 					removeMousewheel();


### PR DESCRIPTION
Fixes left positioning when pane is removed and scrollbar was positioned on the left of content

I haven't tried to figure out how to recompile dependencies, just changed the source (I have the script compiling elsewhere in my asset compilation workflow)