### PR TITLE
Preserve user previous outline style

### DIFF
--- a/style/jquery.jscrollpane.css
+++ b/style/jquery.jscrollpane.css
@@ -113,3 +113,8 @@
 {
 	margin: 0 -3px 0 0;
 }
+
+/* To preserve user's style concerning that ugly chrome default blue outline */
+*:focus {
+    outline: inherit;
+}


### PR DESCRIPTION
Without this rule, jscrollpane readded the blue focus outline in chrome
