### PR TITLE
Fixed CommonJS export

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -71,7 +71,7 @@
       define(['jquery'], factory);
   } else if (typeof exports === 'object') {
       // Node/CommonJS style for Browserify
-      module.exports = factory;
+      module.exports = factory(require('jquery'));
   } else {
       // Browser globals
       factory(jQuery);


### PR DESCRIPTION
Actually, the plugin won't get registered into jQuery when using CommonJS environments. This patch fixes it.