### PR TITLE
Call setTimeout with function expression.

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -542,7 +542,9 @@
 						if (dirY !== 0) {
 							jsp.scrollByY(dirY * settings.arrowButtonSpeed);
 						}
-						scrollTimeout = setTimeout(doScroll, isFirst ? settings.initialDelay : settings.arrowRepeatFreq);
+						scrollTimeout = setTimeout(function() {
+							doScroll();
+						}, isFirst ? settings.initialDelay : settings.arrowRepeatFreq);
 						isFirst = false;
 					};
 
@@ -598,7 +600,9 @@
 											cancelClick();
 											return;
 										}
-										scrollTimeout = setTimeout(doScroll, isFirst ? settings.initialDelay : settings.trackClickRepeatFreq);
+										scrollTimeout = setTimeout(function() {
+											doScroll();
+										}, isFirst ? settings.initialDelay : settings.trackClickRepeatFreq);
 										isFirst = false;
 									},
 									cancelClick = function()
@@ -648,7 +652,9 @@
 											cancelClick();
 											return;
 										}
-										scrollTimeout = setTimeout(doScroll, isFirst ? settings.initialDelay : settings.trackClickRepeatFreq);
+										scrollTimeout = setTimeout(function() {
+											doScroll();
+										}, isFirst ? settings.initialDelay : settings.trackClickRepeatFreq);
 										isFirst = false;
 									},
 									cancelClick = function()


### PR DESCRIPTION
In order to prevent vulnerabilities, the `setTimeout` and `setInterval` functions should be called only with function expressions as their first argument.
