### PR TITLE
Fixing invalid selector

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -1130,7 +1130,7 @@
 				$(document.body).data('jspHijack', true);
 
 				// use live handler to also capture newly created links
-				$(document.body).delegate('a[href*=#]', 'click', function(event) {
+				$(document.body).delegate('a[href*="#"]', 'click', function(event) {
 					// does the link point to the same page?
 					// this also takes care of cases with a <base>-Tag or Links not starting with the hash #
 					// e.g. <a href="index.html#test"> when the current url already is index.html


### PR DESCRIPTION
The selector `'a[href*=#]'` is invalid, though it is supported by older versions of jQuery. 

To see this, try putting `$('a[href*=#]')` or `document.querySelectorAll('a[href*=#]')` into the console of a page.

The selector can be replaced by `'a[href*="#"]'`. To test this, try `$('a[href*="#"]')` or `document.querySelectorAll('a[href*="#"]')` in a console



