### PR TITLE
Set drag bar width/height with .css instead of .width/.height

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -480,7 +480,7 @@
 					} else if (horizontalDragWidth < settings.horizontalDragMinWidth) {
 						horizontalDragWidth = settings.horizontalDragMinWidth;
 					}
-					horizontalDrag.width(horizontalDragWidth + 'px');
+					horizontalDrag.css('width', horizontalDragWidth + 'px');
 					dragMaxX = horizontalTrackWidth - horizontalDragWidth;
 					_positionDragX(horizontalDragPosition); // To update the state for the arrow buttons
 				}
@@ -491,7 +491,7 @@
 					} else if (verticalDragHeight < settings.verticalDragMinHeight) {
 						verticalDragHeight = settings.verticalDragMinHeight;
 					}
-					verticalDrag.height(verticalDragHeight + 'px');
+					verticalDrag.css('height', verticalDragHeight + 'px');
 					dragMaxY = verticalTrackHeight - verticalDragHeight;
 					_positionDragY(verticalDragPosition); // To update the state for the arrow buttons
 				}


### PR DESCRIPTION
Using .width or .height sets the content width/height of the box, which includes border width, but the calculations to find horizontalDragWidth/verticalDragHeight are for the inner width/height (without borders.)

Compare:
http://www.lakora.us/jScrollPane/demo1.html (old)
http://www.lakora.us/jScrollPane/demo2.html (new)
