### PR TITLE
Fix README and add Ruby gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ jScrollPane is a [jQuery](http://www.jquery.com/) plugin which allows you to rep
 
 To see a bunch of examples of jScrollPane in action please visit the [jScrollPane website](http://jscrollpane.kelvinluck.com/). All of the code for the website is available from this repository so please feel free to download and use it!
 
-# How to get it
+## How to get it
 
-## CND
-Up-to-date CND version is kindly provided by: [CNDJS jScrollPane](https://cdnjs.com/libraries/jScrollPane)
+### CDN
+Up-to-date CDN version is kindly provided by: [CDNJS jScrollPane](https://cdnjs.com/libraries/jScrollPane)
 
-## NPM
+### NPM
 Up-to-date Node version [jScrollPane](https://www.npmjs.com/package/jscrollpane) is also available from NPM.
+
+### Ruby on Rails
+
+jScrollPane [packed as Ruby gem](https://github.com/bodrovis/jscrollpane-rails) is also available.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@ jScrollPane is a [jQuery](http://www.jquery.com/) plugin which allows you to rep
 
 To see a bunch of examples of jScrollPane in action please visit the [jScrollPane website](http://jscrollpane.kelvinluck.com/). All of the code for the website is available from this repository so please feel free to download and use it!
 
-## How to get it
+# How to get it
 
-### CDN
+## CDN
 Up-to-date CDN version is kindly provided by: [CDNJS jScrollPane](https://cdnjs.com/libraries/jScrollPane)
 
-### NPM
+## NPM
 Up-to-date Node version [jScrollPane](https://www.npmjs.com/package/jscrollpane) is also available from NPM.
 
-### Ruby on Rails
-
+## Ruby on Rails
 jScrollPane [packed as Ruby gem](https://github.com/bodrovis/jscrollpane-rails) is also available.
 
 ## Issues


### PR DESCRIPTION
jScrollPane is available as Ruby gem (gem is a fancy word for library in Ruby) :) https://github.com/bodrovis/jscrollpane-rails

What's interesting, the gem was already mentioned [on the website](http://jscrollpane.kelvinluck.com/) by  the previous maintainer but for some reason in the "Simple examples" section. Perhaps, it should be moved to "Download".