### PR TITLE
Integrate touch events

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -430,9 +430,11 @@
                     verticalDrag = verticalTrack.find('>.jspDrag');
 
                     if (settings.showArrows) {
-                        arrowUp = $('<a class="jspArrow jspArrowUp"></a>').on('mousedown.jsp', getArrowScroll(0, -1)).on('click.jsp', nil);
+                        arrowUp = $('<a class="jspArrow jspArrowUp"></a>')
+                            .on('mousedown.jsp touchstart.jsp', getArrowScroll(0, -1))
+                            .on('click.jsp', nil);
                         arrowDown = $('<a class="jspArrow jspArrowDown"></a>')
-                            .on('mousedown.jsp', getArrowScroll(0, 1))
+                            .on('mousedown.jsp touchstart.jsp', getArrowScroll(0, 1))
                             .on('click.jsp', nil);
                         if (settings.arrowScrollOnHover) {
                             arrowUp.on('mouseover.jsp', getArrowScroll(0, -1, arrowUp));
@@ -454,19 +456,20 @@
                         .on('mouseleave', function () {
                             verticalDrag.removeClass('jspHover');
                         })
-                        .on('mousedown.jsp', function (e) {
+                        .on('mousedown.jsp touchstart.jsp', function (e) {
                             // Stop IE from allowing text selection
                             $('html').on('dragstart.jsp selectstart.jsp', nil);
 
                             verticalDrag.addClass('jspActive');
 
-                            var startY = e.pageY - verticalDrag.position().top;
+                            var startY = (e.pageY || e.originalEvent.changedTouches[0].pageY) - verticalDrag.position().top;
 
                             $('html')
-                                .on('mousemove.jsp', function (e) {
-                                    positionDragY(e.pageY - startY, false);
+                                .on('mousemove.jsp touchmove.jsp', function (e) {
+                                    const pageY = e.pageY || e.originalEvent.changedTouches[0].pageY
+                                    positionDragY(pageY - startY, false);
                                 })
-                                .on('mouseup.jsp mouseleave.jsp', cancelDrag);
+                                .on('mouseup.jsp touchend.jsp touchcancel.jsp mouseleave.jsp', cancelDrag);
                             return false;
                         });
                     sizeVerticalScrollbar();
@@ -511,10 +514,10 @@
 
                     if (settings.showArrows) {
                         arrowLeft = $('<a class="jspArrow jspArrowLeft"></a>')
-                            .on('mousedown.jsp', getArrowScroll(-1, 0))
+                            .on('mousedown.jsp touchstart.jsp', getArrowScroll(-1, 0))
                             .on('click.jsp', nil);
                         arrowRight = $('<a class="jspArrow jspArrowRight"></a>')
-                            .on('mousedown.jsp', getArrowScroll(1, 0))
+                            .on('mousedown.jsp touchstart.jsp', getArrowScroll(1, 0))
                             .on('click.jsp', nil);
                         if (settings.arrowScrollOnHover) {
                             arrowLeft.on('mouseover.jsp', getArrowScroll(-1, 0, arrowLeft));
@@ -530,19 +533,20 @@
                         .on('mouseleave', function () {
                             horizontalDrag.removeClass('jspHover');
                         })
-                        .on('mousedown.jsp', function (e) {
+                        .on('mousedown.jsp touchstart.jsp', function (e) {
                             // Stop IE from allowing text selection
                             $('html').on('dragstart.jsp selectstart.jsp', nil);
 
                             horizontalDrag.addClass('jspActive');
 
-                            var startX = e.pageX - horizontalDrag.position().left;
+                            var startX = (e.pageX || e.originalEvent.changedTouches[0].pageX) - horizontalDrag.position().left;
 
                             $('html')
-                                .on('mousemove.jsp', function (e) {
-                                    positionDragX(e.pageX - startX, false);
+                                .on('mousemove.jsp touchmove.jsp', function (e) {
+                                    const pageX = e.pageX || e.originalEvent.changedTouches[0].pageX
+                                    positionDragX(pageX - startX, false);
                                 })
-                                .on('mouseup.jsp mouseleave.jsp', cancelDrag);
+                                .on('mouseup.jsp touchend.jsp touchcancel.jsp mouseleave.jsp', cancelDrag);
                             return false;
                         });
                     horizontalTrackWidth = container.innerWidth();
@@ -656,7 +660,7 @@
 
                 doScroll();
 
-                eve = ele ? 'mouseout.jsp' : 'mouseup.jsp';
+                eve = ele ? 'mouseout.jsp' : 'mouseup.jsp touchend.jsp touchcancel.jsp';
                 ele = ele || $('html');
                 ele.on(eve, function () {
                     arrow.removeClass('jspActive');
@@ -671,16 +675,16 @@
             function initClickOnTrack() {
                 removeClickOnTrack();
                 if (isScrollableV) {
-                    verticalTrack.on('mousedown.jsp', function (e) {
+                    verticalTrack.on('mousedown.jsp touchstart.jsp', function (e) {
                         if (e.originalTarget === undefined || e.originalTarget == e.currentTarget) {
                             var clickedTrack = $(this),
                                 offset = clickedTrack.offset(),
-                                direction = e.pageY - offset.top - verticalDragPosition,
+                                direction = (e.pageY || e.originalEvent.changedTouches[0].pageY) - offset.top - verticalDragPosition,
                                 scrollTimeout,
                                 isFirst = true,
                                 doScroll = function () {
                                     var offset = clickedTrack.offset(),
-                                        pos = e.pageY - offset.top - verticalDragHeight / 2,
+                                        pos = (e.pageY || e.originalEvent.changedTouches[0].pageY) - offset.top - verticalDragHeight / 2,
                                         contentDragY = paneHeight * settings.scrollPagePercent,
                                         dragY = (dragMaxY * contentDragY) / (contentHeight - paneHeight);
                                     if (direction < 0) {
@@ -707,26 +711,26 @@
                                         clearTimeout(scrollTimeout);
                                     }
                                     scrollTimeout = null;
-                                    $(document).off('mouseup.jsp', cancelClick);
+                                    $(document).off('mouseup.jsp touchend.jsp touchcancel.jsp', cancelClick);
                                 };
                             doScroll();
-                            $(document).on('mouseup.jsp', cancelClick);
+                            $(document).on('mouseup.jsp touchend.jsp touchcancel.jsp', cancelClick);
                             return false;
                         }
                     });
                 }
 
                 if (isScrollableH) {
-                    horizontalTrack.on('mousedown.jsp', function (e) {
+                    horizontalTrack.on('mousedown.jsp touchstart.jsp', function (e) {
                         if (e.originalTarget === undefined || e.originalTarget == e.currentTarget) {
                             var clickedTrack = $(this),
                                 offset = clickedTrack.offset(),
-                                direction = e.pageX - offset.left - horizontalDragPosition,
+                                direction = (e.pageX || e.originalEvent.changedTouches[0].pageX) - offset.left - horizontalDragPosition,
                                 scrollTimeout,
                                 isFirst = true,
                                 doScroll = function () {
                                     var offset = clickedTrack.offset(),
-                                        pos = e.pageX - offset.left - horizontalDragWidth / 2,
+                                        pos = (e.pageX || e.originalEvent.changedTouches[0].pageX) - offset.left - horizontalDragWidth / 2,
                                         contentDragX = paneWidth * settings.scrollPagePercent,
                                         dragX = (dragMaxX * contentDragX) / (contentWidth - paneWidth);
                                     if (direction < 0) {
@@ -753,10 +757,10 @@
                                         clearTimeout(scrollTimeout);
                                     }
                                     scrollTimeout = null;
-                                    $(document).off('mouseup.jsp', cancelClick);
+                                    $(document).off('mouseup.jsp touchend.jsp touchcancel.jsp', cancelClick);
                                 };
                             doScroll();
-                            $(document).on('mouseup.jsp', cancelClick);
+                            $(document).on('mouseup.jsp touchend.jsp touchcancel.jsp', cancelClick);
                             return false;
                         }
                     });
@@ -765,15 +769,15 @@
 
             function removeClickOnTrack() {
                 if (horizontalTrack) {
-                    horizontalTrack.off('mousedown.jsp');
+                    horizontalTrack.off('mousedown.jsp touchstart.jsp');
                 }
                 if (verticalTrack) {
-                    verticalTrack.off('mousedown.jsp');
+                    verticalTrack.off('mousedown.jsp touchstart.jsp');
                 }
             }
 
             function cancelDrag() {
-                $('html').off('dragstart.jsp selectstart.jsp mousemove.jsp mouseup.jsp mouseleave.jsp');
+                $('html').off('dragstart.jsp selectstart.jsp mousemove.jsp touchmove.jsp mouseup.jsp touchend.jsp touchcancel.jsp mouseleave.jsp');
 
                 if (verticalDrag) {
                     verticalDrag.removeClass('jspActive');


### PR DESCRIPTION
Touch events are missing in the scroll pane implementation, so any phone or tablet (e.g., a device with a touch screen) can now use the scroll pane properly. Before this change the scrollbar would not work on touch devices.